### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/xixu-me/prompt-library/security/code-scanning/6](https://github.com/xixu-me/prompt-library/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, `contents: read` is sufficient, as the jobs only read files and do not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added to each job individually. In this case, adding it at the root level is more efficient since all jobs share the same minimal permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
